### PR TITLE
Do not retrieve individual keys on dqlite backup

### DIFF
--- a/main.go
+++ b/main.go
@@ -192,16 +192,12 @@ func backup_dqlite(ep string, dir string) error {
 	}
 	for i, kv := range resp {
 		logrus.Debugf("%d) %s\n", i, kv.Key)
-		data, err := c.Get(ctx, string(kv.Key))
-		if err != nil {
-			return fmt.Errorf("couldn't get key %s: %w", kv.Key, err)
-		}
 
 		keyfile, datafile := getFileNamesForKey(i)
 		if err := os.WriteFile(keyfile, kv.Key, 0640); err != nil {
 			return fmt.Errorf("failed to write key file %q: %w", keyfile, err)
 		}
-		if err := os.WriteFile(datafile, data.Data, 0640); err != nil {
+		if err := os.WriteFile(datafile, kv.Data, 0640); err != nil {
 			return fmt.Errorf("failed to write data file %q: %w", datafile, err)
 		}
 	}


### PR DESCRIPTION
### Summary

Closes https://github.com/canonical/microk8s/issues/2339

When backing up dqlite, use key-values as retrieved from the original list query, do not attempt to retrieve them individually.

This also has the side-effect of speeding up the backup operation, especially for large database sizes.